### PR TITLE
API Routes Development

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3,12 +3,14 @@
 ## Technology Stack
 
 ### Frontend
+
 - **Framework**: SvelteKit
 - **Styling**: Tailwind CSS
 - **Drag and Drop**: svelte-dnd-action
 - **Language**: TypeScript
 
 ### Backend
+
 - **API**: SvelteKit API routes
 - **Data Storage**: JSON files
 - **No external database required**
@@ -32,6 +34,7 @@ kanban/
 │   │   │   └── task.ts              # TypeScript interfaces for task data
 │   │   └── utils/
 │   │       ├── taskSort.ts          # Utility for sorting tasks by date
+│   │       ├── taskFileUtils.ts     # Helper functions for api routes
 │   │       └── dateFormat.ts        # Date formatting utilities
 │   ├── routes/
 │   │   ├── +page.svelte            # Main page with Kanban board
@@ -60,22 +63,24 @@ kanban/
 ## Data Model
 
 ### Task Interface
+
 ```typescript
 interface Task {
-  id: string;              // Unique identifier
-  title: string;           // Task title (required)
-  description?: string;    // Optional description
-  status: "todo" | "doing" | "done";  // Current column
-  labels?: string[];       // Optional array of labels
-  assignee?: string;       // Optional assignee name
+  id: string; // Unique identifier
+  title: string; // Task title (required)
+  description?: string; // Optional description
+  status: 'todo' | 'doing' | 'done'; // Current column
+  labels?: string[]; // Optional array of labels
+  assignee?: string; // Optional assignee name
   estimatedCompletion?: Date; // Estimated completion date
-  completedAt?: Date;      // When the task was marked as done
-  createdAt: Date;         // Creation timestamp
-  updatedAt: Date;         // Last update timestamp
+  completedAt?: Date; // When the task was marked as done
+  createdAt: Date; // Creation timestamp
+  updatedAt: Date; // Last update timestamp
 }
 ```
 
 ### JSON Data Structure
+
 ```json
 [
   {
@@ -88,7 +93,7 @@ interface Task {
     "estimatedCompletion": "2023-06-30T00:00:00.000Z",
     "createdAt": "2023-06-01T12:00:00.000Z",
     "updatedAt": "2023-06-01T12:00:00.000Z"
-  },
+  }
   // More tasks...
 ]
 ```
@@ -96,69 +101,83 @@ interface Task {
 ## Component Architecture
 
 ### Board Component
+
 - Contains the three columns
 - Handles data loading and overall layout
 - Manages modals and toast notifications
 
 ### Column Component
+
 - Displays a list of tasks for a specific status
 - Handles drag-and-drop targets
 - Manages column-specific sorting
 
 ### TaskCard Component
+
 - Displays individual task details
 - Serves as drag source
 - Provides controls for editing and deleting
 
 ### TaskModal Component
+
 - Form for creating and editing tasks
 - Validation logic
 - Submit handling
 
 ### ConfirmDialog Component
+
 - Simple confirmation dialog for destructive actions
 - Customizable message and action buttons
 
 ### Toast Component
+
 - Displays success and error notifications
 - Auto-dismisses after timeout
 
 ## API Routes
 
 ### GET /api/tasks
+
 - Returns all tasks as JSON array
 - Sorted by default order
 
 ### POST /api/tasks
+
 - Creates a new task
 - Validates required fields
 - Returns the created task with generated ID
 
 ### GET /api/tasks/[id]
+
 - Returns a specific task by ID
 - 404 if not found
 
 ### PUT /api/tasks/[id]
+
 - Updates a specific task
 - Handles status changes and updates timestamps
 - Returns the updated task
 
 ### DELETE /api/tasks/[id]
+
 - Deletes a specific task
 - Returns success message
 
 ## State Management
+
 - Use SvelteKit's built-in stores for managing application state
 - Task data loaded on initial page load
 - Local updates for optimistic UI changes
 - Server sync for persistence
 
 ## Error Handling
+
 - Toast notifications for user-facing errors
 - Console logging for development debugging
 - Input validation to prevent bad data
 
 ## Performance Considerations
+
 - Minimizing re-renders using Svelte's reactivity
 - Efficient sorting and filtering
 - Local data storage for quick access and modifications

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ npm run check
 - Import types with the `type` keyword (e.g., `import type { Task } from '$lib/types/task'`)
 - Use the '$lib' alias for imports from the lib directory
 - Sort imports in a consistent order: external libraries first, then internal modules
+- Group imports by category with a blank line between groups
+- Prefer named imports over default imports when multiple items are needed from a module
 
 ### General Guidelines
 
@@ -51,6 +53,11 @@ npm run check
 2. Follow the existing component structure and naming conventions
 3. Keep components small and focused on a single responsibility
 4. Use Svelte's built-in reactivity whenever possible
+5. Extract reusable logic into utility functions
+6. Use consistent error handling patterns throughout the application
+7. Keep files organized in logical directories based on functionality
+8. Comment complex logic but prefer self-documenting code through clear naming
+9. Avoid duplicating code - create shared modules for common operations
 
 ### TypeScript
 
@@ -60,6 +67,10 @@ npm run check
 - Use `undefined` instead of `null` for optional values to match TypeScript's strict null checking
 - Always use explicit typing for complex objects, especially when creating new instances
 - Use type assertions (`as Type`) only when TypeScript cannot infer types correctly
+- Create utility types for common patterns (e.g., Omit<T, K>, Pick<T, K>)
+- Handle type conversion carefully, especially with dates and serialized data
+- Use Record<string, unknown> instead of any for objects with unknown structure
+- Run TypeScript checks frequently to ensure type safety throughout development
 
 ```typescript
 // Example
@@ -115,6 +126,11 @@ interface Task {
 - Use 'node:' prefix for Node.js built-in modules (e.g., 'node:fs', 'node:path')
 - Handle JSON parsing exceptions with try/catch blocks
 - Return consistent response formats for both success and error cases
+- Create helper functions for common operations like error responses
+- Centralize file path constants to avoid string duplication
+- Use utility functions to handle serialization/deserialization of complex types (like Date objects)
+- Apply the DRY (Don't Repeat Yourself) principle by extracting repeated logic into reusable functions
+- Implement thorough validation before performing operations on data
 
 ### Git Workflow
 
@@ -131,6 +147,26 @@ interface Task {
 2. Updates are made through SvelteKit API routes
 3. Svelte stores maintain the application state
 4. Components react to state changes
+
+### Code Organization
+
+1. **Utility Pattern**:
+   - Place reusable functions in dedicated utility files
+   - Group related utilities by domain (e.g., date handling, task operations)
+   - Keep utility functions pure when possible for easier testing
+
+2. **File Structure**:
+   - `/lib/types` - TypeScript interfaces and types
+   - `/lib/utils` - Utility functions
+   - `/lib/components` - Reusable UI components
+   - `/lib/stores` - Svelte stores
+   - `/routes/api` - API endpoints
+   - `/routes` - Page components
+
+3. **API Layer**:
+   - Centralize file operations in utility functions
+   - Use consistent error handling patterns
+   - Convert between in-memory and serialized representations
 
 ### Component Hierarchy
 

--- a/HISTORY_MAX.md
+++ b/HISTORY_MAX.md
@@ -3,6 +3,7 @@
 ## Project Setup and Requirements Gathering
 
 1. Established project requirements:
+
    - SvelteKit as the frontend framework
    - Tailwind CSS for styling
    - TypeScript for type safety
@@ -10,6 +11,7 @@
    - JSON file storage via SvelteKit API routes
 
 2. Created specification documents:
+
    - FUNCTIONAL_MAX.md - Detailed functional requirements
    - ARCHITECTURE_MAX.md - Technical architecture specifications
    - CLAUDE.md - Development guidelines and standards
@@ -23,23 +25,29 @@
 ## Implementation Progress
 
 1. Implemented TypeScript interfaces:
+
    - Created task.ts with Task interface definitions
    - Defined TaskStatus type and interfaces for new/updated tasks
 
 2. Implemented API endpoints:
+
    - Created /api/tasks endpoint with GET and POST handlers
+   - Implemented /api/tasks/[id] endpoints with GET, PUT, and DELETE handlers
    - Added task sorting logic based on column and date
-   - Fixed TypeScript errors in endpoint implementation
+   - Created utility functions for task data operations
    - Added proper error handling and validation
+   - Implemented date serialization/deserialization for API
 
 3. Set up data storage:
    - Created static/data/tasks.json for JSON storage
+   - Added helper functions in taskFileUtils.ts for common file operations
 
 ## Next Steps
 
 The following items are still pending implementation:
 
 1. Frontend Components:
+
    - Board.svelte - Main container component
    - Column.svelte - Individual column component
    - TaskCard.svelte - Individual task card component
@@ -48,14 +56,10 @@ The following items are still pending implementation:
    - Toast.svelte - Notification component
 
 2. Task Store:
+
    - Implement Svelte store for task state management
 
-3. API Endpoints for Individual Tasks:
-   - GET /api/tasks/[id] - Get specific task
-   - PUT /api/tasks/[id] - Update specific task
-   - DELETE /api/tasks/[id] - Delete specific task
-
-4. Page Components:
+3. Page Components:
    - Update +page.svelte to display Kanban board
    - Add data loading logic in +page.ts
 
@@ -65,25 +69,34 @@ The following items are still pending implementation:
 kanban/
 ├── src/
 │   ├── lib/
+│   │   ├── components/
+│   │   │   └── Board.svelte        # Main board component
 │   │   ├── types/
-│   │   │   └── task.ts              # Task interfaces
+│   │   │   └── task.ts             # Task interfaces
+│   │   └── utils/
+│   │       ├── dateFormat.ts       # Date formatting utilities
+│   │       ├── taskFileUtils.ts    # Task file operations helpers
+│   │       └── taskSort.ts         # Task sorting utilities
 │   ├── routes/
-│   │   ├── +page.svelte            # Main page (to be implemented)
-│   │   ├── +layout.svelte          # Layout wrapper
+│   │   ├── +page.svelte           # Main page (to be implemented)
+│   │   ├── +layout.svelte         # Layout wrapper
 │   │   └── api/
 │   │       ├── tasks/
-│   │       │   └── +server.ts       # GET (all tasks), POST (new task)
-│   └── app.html                    # Base HTML template
+│   │       │   ├── +server.ts      # GET (all tasks), POST (new task)
+│   │       │   └── [id]/
+│   │       │       └── +server.ts  # GET, PUT, DELETE (individual task)
+│   └── app.html                   # Base HTML template
 ├── static/
 │   └── data/
-│       └── tasks.json              # JSON file for task storage
-├── ARCHITECTURE_MAX.md             # Architectural specification
-├── CLAUDE.md                       # Development guidelines
-├── FUNCTIONAL_MAX.md               # Functional specification
-├── .prettierrc                     # Prettier configuration
-├── eslint.config.js                # ESLint configuration
-├── package.json                    # Project dependencies
-└── README.md                       # Project documentation
+│       └── tasks.json             # JSON file for task storage
+├── ARCHITECTURE.md            # Architectural specification
+├── CLAUDE.md                      # Development guidelines
+├── FUNCTIONAL.md              # Functional specification
+├── HISTORY_MAX.md                 # Project history and progress
+├── .prettierrc                    # Prettier configuration
+├── eslint.config.js               # ESLint configuration
+├── package.json                   # Project dependencies
+└── README.md                      # Project documentation
 ```
 
 ## Development Standards
@@ -97,10 +110,36 @@ For anyone continuing development, please refer to:
 ## Key Technical Decisions
 
 1. **Data Structure**: Flat array of tasks with column identifiers (status field)
-2. **Sorting**: 
+2. **Sorting**:
    - "To Do" and "Doing" columns: sort by estimatedCompletion (closest dates first)
    - "Done" column: sort by completedAt (most recently completed first)
 3. **API Design**: RESTful endpoints with appropriate HTTP status codes
-4. **Styling**: Tailwind CSS with minimal custom CSS
-5. **Form Validation**: Simple manual validation (no validation libraries)
-6. **Error Handling**: Toast notifications for user-facing errors
+4. **Date Handling**: 
+   - Dates stored as Date objects in memory
+   - Converted to ISO strings for JSON storage
+   - Helper functions for consistent date serialization/deserialization
+5. **Code Organization**:
+   - Utility functions extracted to reusable modules
+   - Common operations (like file reading/writing) centralized in utility files
+6. **Styling**: Tailwind CSS with minimal custom CSS
+7. **Form Validation**: Simple manual validation (no validation libraries)
+8. **Error Handling**: Toast notifications for user-facing errors
+
+## Latest Implementation Details
+
+1. **Task API Endpoints**:
+   - Implemented all CRUD operations for tasks
+   - GET /api/tasks - List all tasks with sorting
+   - POST /api/tasks - Create a new task
+   - GET /api/tasks/[id] - Retrieve a specific task
+   - PUT /api/tasks/[id] - Update a specific task
+   - DELETE /api/tasks/[id] - Delete a specific task
+
+2. **Helper Functions**:
+   - Created taskFileUtils.ts with common file operations
+   - Implemented date conversion for proper serialization/deserialization
+   - Added error response standardization
+
+3. **Automatic Date Updates**:
+   - completedAt automatically set when status changes to "done"
+   - updatedAt automatically maintained on all updates

--- a/src/lib/types/task.ts
+++ b/src/lib/types/task.ts
@@ -1,25 +1,20 @@
 export interface Task {
-  id: string;              // Unique identifier
-  title: string;           // Task title (required)
-  description?: string;    // Optional description
-  status: "todo" | "doing" | "done";  // Current column
-  labels?: string[];       // Optional array of labels
-  assignee?: string;       // Optional assignee name
-  estimatedCompletion?: Date; // Estimated completion date
-  completedAt?: Date;      // When the task was marked as done
-  createdAt: Date;         // Creation timestamp
-  updatedAt: Date;         // Last update timestamp
+  id: string;
+  title: string;
+  description?: string;
+  status: 'todo' | 'doing' | 'done';
+  labels?: string[];
+  assignee?: string;
+  estimatedCompletion?: Date;
+  completedAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
-export type TaskStatus = "todo" | "doing" | "done";
+export type TaskStatus = 'todo' | 'doing' | 'done';
 
 export interface NewTask extends Omit<Task, 'id' | 'createdAt' | 'updatedAt' | 'completedAt'> {
   // Fields required when creating a new task
   title: string;
   status: TaskStatus;
-}
-
-export interface TaskUpdate extends Partial<Omit<Task, 'id' | 'createdAt'>> {
-  // Fields that can be updated
-  updatedAt: Date;
 }

--- a/src/lib/utils/taskFileUtils.ts
+++ b/src/lib/utils/taskFileUtils.ts
@@ -1,0 +1,76 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Task } from '$lib/types/task';
+
+// Path to the tasks.json file in the static directory
+export const tasksFilePath = path.join(process.cwd(), 'static/data/tasks.json');
+
+// Helper function to create error responses
+export const errorResponse = (message: string, status: number = 500) => {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+};
+
+// Helper function to read tasks from file
+export const readTasks = (): Task[] => {
+  // Check if the file exists, create it if it doesn't
+  if (!fs.existsSync(tasksFilePath)) {
+    fs.writeFileSync(tasksFilePath, '[]', 'utf-8');
+    return [];
+  }
+
+  // Read the tasks from the JSON file
+  const tasksData = fs.readFileSync(tasksFilePath, 'utf-8');
+  const tasks = JSON.parse(tasksData);
+
+  // Convert date strings to Date objects
+  return tasks.map((task: Task) => {
+    // Convert string dates to Date objects
+    if (task.estimatedCompletion && typeof task.estimatedCompletion === 'string') {
+      task.estimatedCompletion = new Date(task.estimatedCompletion);
+    }
+    if (task.completedAt && typeof task.completedAt === 'string') {
+      task.completedAt = new Date(task.completedAt);
+    }
+    if (task.createdAt && typeof task.createdAt === 'string') {
+      task.createdAt = new Date(task.createdAt);
+    }
+    if (task.updatedAt && typeof task.updatedAt === 'string') {
+      task.updatedAt = new Date(task.updatedAt);
+    }
+    return task;
+  });
+};
+
+/**
+ * Helper function to write tasks to file
+ * Converts Date objects to ISO strings for JSON serialization
+ */
+export const writeTasks = (tasks: Task[]): void => {
+  // Deep clone and convert all Date objects to strings for JSON serialization
+  const tasksToWrite = tasks.map(task => {
+    // Create a new object for serialization
+    const serializedTask: Record<string, unknown> = { ...task };
+
+    if (serializedTask.estimatedCompletion instanceof Date) {
+      serializedTask.estimatedCompletion = serializedTask.estimatedCompletion.toISOString();
+    }
+    if (serializedTask.completedAt instanceof Date) {
+      serializedTask.completedAt = serializedTask.completedAt.toISOString();
+    }
+    if (serializedTask.createdAt instanceof Date) {
+      serializedTask.createdAt = serializedTask.createdAt.toISOString();
+    }
+    if (serializedTask.updatedAt instanceof Date) {
+      serializedTask.updatedAt = serializedTask.updatedAt.toISOString();
+    }
+
+    return serializedTask;
+  });
+
+  fs.writeFileSync(tasksFilePath, JSON.stringify(tasksToWrite, null, 2), 'utf-8');
+};

--- a/src/routes/api/tasks/+server.ts
+++ b/src/routes/api/tasks/+server.ts
@@ -1,11 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from '@sveltejs/kit';
-import fs from 'node:fs';
-import path from 'node:path';
 import type { Task, TaskStatus } from '$lib/types/task';
-
-// Path to the tasks.json file in the static directory
-const tasksFilePath = path.join(process.cwd(), 'static/data/tasks.json');
+import { readTasks, writeTasks, errorResponse } from '$lib/utils/taskFileUtils';
 
 /**
  * GET handler for /api/tasks
@@ -13,31 +9,27 @@ const tasksFilePath = path.join(process.cwd(), 'static/data/tasks.json');
  */
 export const GET: RequestHandler = async () => {
   try {
-    // Check if the file exists, create it if it doesn't
-    if (!fs.existsSync(tasksFilePath)) {
-      fs.writeFileSync(tasksFilePath, '[]', 'utf-8');
-    }
-
-    // Read the tasks from the JSON file
-    const tasksData = fs.readFileSync(tasksFilePath, 'utf-8');
-    const tasks: Task[] = JSON.parse(tasksData);
+    const tasks = readTasks();
 
     // Sort tasks according to requirements:
     // - "todo" and "doing": sort by estimatedCompletion (closest dates first)
     // - "done": sort by completedAt (most recently completed first)
     const sortedTasks = [...tasks].sort((a, b) => {
-      if (a.status === 'done' && b.status === 'done') {
+      const isDoneA = a.status === 'done';
+      const isDoneB = b.status === 'done';
+
+      if (isDoneA && isDoneB) {
         // Sort "done" tasks by completedAt (most recent first)
         const aDate = a.completedAt ? new Date(a.completedAt).getTime() : 0;
         const bDate = b.completedAt ? new Date(b.completedAt).getTime() : 0;
         return bDate - aDate; // Descending order (newest first)
-      } else if (a.status !== 'done' && b.status !== 'done') {
+      } else if (!isDoneA && !isDoneB) {
         // Sort "todo" and "doing" tasks by estimatedCompletion (closest first)
         const aDate = a.estimatedCompletion ? new Date(a.estimatedCompletion).getTime() : Infinity;
         const bDate = b.estimatedCompletion ? new Date(b.estimatedCompletion).getTime() : Infinity;
         return aDate - bDate; // Ascending order (closest first)
       }
-      
+
       // If comparing tasks from different columns, maintain their column positions
       return 0;
     });
@@ -45,12 +37,7 @@ export const GET: RequestHandler = async () => {
     return json(sortedTasks);
   } catch (error) {
     console.error('Error reading tasks:', error);
-    return new Response(JSON.stringify({ error: 'Failed to fetch tasks' }), {
-      status: 500,
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    });
+    return errorResponse('Failed to fetch tasks');
   }
 };
 
@@ -61,53 +48,41 @@ export const GET: RequestHandler = async () => {
 export const POST: RequestHandler = async ({ request }) => {
   try {
     const taskData = await request.json();
-    
+
     // Validate required fields
     if (!taskData.title || !taskData.status) {
-      return new Response(JSON.stringify({ error: 'Title and status are required' }), {
-        status: 400,
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      });
+      return errorResponse('Title and status are required', 400);
     }
-    
+
     // Read existing tasks
-    let tasks: Task[] = [];
-    if (fs.existsSync(tasksFilePath)) {
-      const tasksData = fs.readFileSync(tasksFilePath, 'utf-8');
-      tasks = JSON.parse(tasksData);
-    }
-    
+    const tasks = readTasks();
+
     // Create new task with generated fields
     const now = new Date();
     const newTask: Task = {
+      // Include original properties from taskData
+      ...taskData,
+      // Override or add required properties
       id: crypto.randomUUID(),
-      title: taskData.title,
-      description: taskData.description || '',
       status: taskData.status as TaskStatus,
-      labels: taskData.labels || [],
-      assignee: taskData.assignee || '',
-      estimatedCompletion: taskData.estimatedCompletion ? new Date(taskData.estimatedCompletion) : undefined,
+      // Format dates properly
+      estimatedCompletion: taskData.estimatedCompletion
+        ? new Date(taskData.estimatedCompletion)
+        : undefined,
       completedAt: taskData.status === 'done' ? now : undefined,
       createdAt: now,
       updatedAt: now
     };
-    
+
     // Add the new task to the array
     tasks.push(newTask);
-    
+
     // Write updated tasks back to the file
-    fs.writeFileSync(tasksFilePath, JSON.stringify(tasks, null, 2), 'utf-8');
-    
+    writeTasks(tasks);
+
     return json(newTask, { status: 201 });
   } catch (error) {
     console.error('Error creating task:', error);
-    return new Response(JSON.stringify({ error: 'Failed to create task' }), {
-      status: 500,
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    });
+    return errorResponse('Failed to create task');
   }
 };

--- a/src/routes/api/tasks/[id]/+server.ts
+++ b/src/routes/api/tasks/[id]/+server.ts
@@ -1,0 +1,187 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from '@sveltejs/kit';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Task } from '$lib/types/task';
+
+// Path to the tasks.json file in the static directory
+const tasksFilePath = path.join(process.cwd(), 'static/data/tasks.json');
+
+/**
+ * GET handler for /api/tasks/[id]
+ * Returns a single task by ID
+ */
+export const GET: RequestHandler = async ({ params }) => {
+  try {
+    // Check if the file exists
+    if (!fs.existsSync(tasksFilePath)) {
+      return new Response(JSON.stringify({ error: 'Tasks file not found' }), {
+        status: 404,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+    }
+
+    // Read the tasks from the JSON file
+    const tasksData = fs.readFileSync(tasksFilePath, 'utf-8');
+    const tasks: Task[] = JSON.parse(tasksData);
+
+    // Find the task with the matching ID
+    const task = tasks.find(t => t.id === params.id);
+
+    if (!task) {
+      return new Response(JSON.stringify({ error: 'Task not found' }), {
+        status: 404,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+    }
+
+    return json(task);
+  } catch (error) {
+    console.error(`Error fetching task ${params.id}:`, error);
+    return new Response(JSON.stringify({ error: 'Failed to fetch task' }), {
+      status: 500,
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
+  }
+};
+
+/**
+ * PUT handler for /api/tasks/[id]
+ * Updates an existing task
+ */
+export const PUT: RequestHandler = async ({ request, params }) => {
+  try {
+    const updateData = await request.json();
+    
+    // Check if tasks file exists
+    if (!fs.existsSync(tasksFilePath)) {
+      return new Response(JSON.stringify({ error: 'Tasks file not found' }), {
+        status: 404,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+    }
+    
+    // Read existing tasks
+    const tasksData = fs.readFileSync(tasksFilePath, 'utf-8');
+    const tasks: Task[] = JSON.parse(tasksData);
+    
+    // Find the task to update
+    const taskIndex = tasks.findIndex(t => t.id === params.id);
+    
+    if (taskIndex === -1) {
+      return new Response(JSON.stringify({ error: 'Task not found' }), {
+        status: 404,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+    }
+    
+    const existingTask = tasks[taskIndex];
+    const now = new Date();
+    
+    // Check if status is changing to 'done'
+    const isCompletingTask = existingTask.status !== 'done' && updateData.status === 'done';
+    
+    // Update the task with new data
+    const updatedTask: Task = {
+      ...existingTask,
+      ...updateData,
+      // Preserve these fields that should not be directly updated by client
+      id: existingTask.id,
+      createdAt: existingTask.createdAt,
+      // Update completion date if task is being marked as done
+      completedAt: isCompletingTask ? now : existingTask.completedAt,
+      // Always update the updatedAt timestamp
+      updatedAt: now
+    };
+    
+    // If dates are provided as strings, convert them to Date objects
+    if (typeof updatedTask.estimatedCompletion === 'string') {
+      updatedTask.estimatedCompletion = new Date(updatedTask.estimatedCompletion);
+    }
+    if (typeof updatedTask.completedAt === 'string') {
+      updatedTask.completedAt = new Date(updatedTask.completedAt);
+    }
+    if (typeof updatedTask.createdAt === 'string') {
+      updatedTask.createdAt = new Date(updatedTask.createdAt);
+    }
+    if (typeof updatedTask.updatedAt === 'string') {
+      updatedTask.updatedAt = new Date(updatedTask.updatedAt);
+    }
+    
+    // Replace the task in the array
+    tasks[taskIndex] = updatedTask;
+    
+    // Write updated tasks back to the file
+    fs.writeFileSync(tasksFilePath, JSON.stringify(tasks, null, 2), 'utf-8');
+    
+    return json(updatedTask);
+  } catch (error) {
+    console.error(`Error updating task ${params.id}:`, error);
+    return new Response(JSON.stringify({ error: 'Failed to update task' }), {
+      status: 500,
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
+  }
+};
+
+/**
+ * DELETE handler for /api/tasks/[id]
+ * Deletes a task by ID
+ */
+export const DELETE: RequestHandler = async ({ params }) => {
+  try {
+    // Check if the file exists
+    if (!fs.existsSync(tasksFilePath)) {
+      return new Response(JSON.stringify({ error: 'Tasks file not found' }), {
+        status: 404,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+    }
+    
+    // Read existing tasks
+    const tasksData = fs.readFileSync(tasksFilePath, 'utf-8');
+    const tasks: Task[] = JSON.parse(tasksData);
+    
+    // Find the task to delete
+    const taskIndex = tasks.findIndex(t => t.id === params.id);
+    
+    if (taskIndex === -1) {
+      return new Response(JSON.stringify({ error: 'Task not found' }), {
+        status: 404,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      });
+    }
+    
+    // Remove the task from the array
+    const deletedTask = tasks.splice(taskIndex, 1)[0];
+    
+    // Write updated tasks back to the file
+    fs.writeFileSync(tasksFilePath, JSON.stringify(tasks, null, 2), 'utf-8');
+    
+    return json({ success: true, deletedTask });
+  } catch (error) {
+    console.error(`Error deleting task ${params.id}:`, error);
+    return new Response(JSON.stringify({ error: 'Failed to delete task' }), {
+      status: 500,
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    });
+  }
+};

--- a/src/routes/api/tasks/[id]/+server.ts
+++ b/src/routes/api/tasks/[id]/+server.ts
@@ -1,11 +1,7 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from '@sveltejs/kit';
-import fs from 'node:fs';
-import path from 'node:path';
 import type { Task } from '$lib/types/task';
-
-// Path to the tasks.json file in the static directory
-const tasksFilePath = path.join(process.cwd(), 'static/data/tasks.json');
+import { readTasks, writeTasks, errorResponse } from '$lib/utils/taskFileUtils';
 
 /**
  * GET handler for /api/tasks/[id]
@@ -13,41 +9,19 @@ const tasksFilePath = path.join(process.cwd(), 'static/data/tasks.json');
  */
 export const GET: RequestHandler = async ({ params }) => {
   try {
-    // Check if the file exists
-    if (!fs.existsSync(tasksFilePath)) {
-      return new Response(JSON.stringify({ error: 'Tasks file not found' }), {
-        status: 404,
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      });
-    }
-
-    // Read the tasks from the JSON file
-    const tasksData = fs.readFileSync(tasksFilePath, 'utf-8');
-    const tasks: Task[] = JSON.parse(tasksData);
+    const tasks = readTasks();
 
     // Find the task with the matching ID
     const task = tasks.find(t => t.id === params.id);
 
     if (!task) {
-      return new Response(JSON.stringify({ error: 'Task not found' }), {
-        status: 404,
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      });
+      return errorResponse('Task not found', 404);
     }
 
     return json(task);
   } catch (error) {
     console.error(`Error fetching task ${params.id}:`, error);
-    return new Response(JSON.stringify({ error: 'Failed to fetch task' }), {
-      status: 500,
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    });
+    return errorResponse('Failed to fetch task');
   }
 };
 
@@ -59,30 +33,14 @@ export const PUT: RequestHandler = async ({ request, params }) => {
   try {
     const updateData = await request.json();
     
-    // Check if tasks file exists
-    if (!fs.existsSync(tasksFilePath)) {
-      return new Response(JSON.stringify({ error: 'Tasks file not found' }), {
-        status: 404,
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      });
-    }
-    
     // Read existing tasks
-    const tasksData = fs.readFileSync(tasksFilePath, 'utf-8');
-    const tasks: Task[] = JSON.parse(tasksData);
+    const tasks = readTasks();
     
     // Find the task to update
     const taskIndex = tasks.findIndex(t => t.id === params.id);
     
     if (taskIndex === -1) {
-      return new Response(JSON.stringify({ error: 'Task not found' }), {
-        status: 404,
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      });
+      return errorResponse('Task not found', 404);
     }
     
     const existingTask = tasks[taskIndex];
@@ -104,35 +62,16 @@ export const PUT: RequestHandler = async ({ request, params }) => {
       updatedAt: now
     };
     
-    // If dates are provided as strings, convert them to Date objects
-    if (typeof updatedTask.estimatedCompletion === 'string') {
-      updatedTask.estimatedCompletion = new Date(updatedTask.estimatedCompletion);
-    }
-    if (typeof updatedTask.completedAt === 'string') {
-      updatedTask.completedAt = new Date(updatedTask.completedAt);
-    }
-    if (typeof updatedTask.createdAt === 'string') {
-      updatedTask.createdAt = new Date(updatedTask.createdAt);
-    }
-    if (typeof updatedTask.updatedAt === 'string') {
-      updatedTask.updatedAt = new Date(updatedTask.updatedAt);
-    }
-    
     // Replace the task in the array
     tasks[taskIndex] = updatedTask;
     
     // Write updated tasks back to the file
-    fs.writeFileSync(tasksFilePath, JSON.stringify(tasks, null, 2), 'utf-8');
+    writeTasks(tasks);
     
     return json(updatedTask);
   } catch (error) {
     console.error(`Error updating task ${params.id}:`, error);
-    return new Response(JSON.stringify({ error: 'Failed to update task' }), {
-      status: 500,
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    });
+    return errorResponse('Failed to update task');
   }
 };
 
@@ -142,46 +81,25 @@ export const PUT: RequestHandler = async ({ request, params }) => {
  */
 export const DELETE: RequestHandler = async ({ params }) => {
   try {
-    // Check if the file exists
-    if (!fs.existsSync(tasksFilePath)) {
-      return new Response(JSON.stringify({ error: 'Tasks file not found' }), {
-        status: 404,
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      });
-    }
-    
     // Read existing tasks
-    const tasksData = fs.readFileSync(tasksFilePath, 'utf-8');
-    const tasks: Task[] = JSON.parse(tasksData);
+    const tasks = readTasks();
     
     // Find the task to delete
     const taskIndex = tasks.findIndex(t => t.id === params.id);
     
     if (taskIndex === -1) {
-      return new Response(JSON.stringify({ error: 'Task not found' }), {
-        status: 404,
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      });
+      return errorResponse('Task not found', 404);
     }
     
     // Remove the task from the array
     const deletedTask = tasks.splice(taskIndex, 1)[0];
     
     // Write updated tasks back to the file
-    fs.writeFileSync(tasksFilePath, JSON.stringify(tasks, null, 2), 'utf-8');
+    writeTasks(tasks);
     
     return json({ success: true, deletedTask });
   } catch (error) {
     console.error(`Error deleting task ${params.id}:`, error);
-    return new Response(JSON.stringify({ error: 'Failed to delete task' }), {
-      status: 500,
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    });
+    return errorResponse('Failed to delete task');
   }
 };

--- a/static/data/tasks.json
+++ b/static/data/tasks.json
@@ -11,6 +11,6 @@
     "assignee": "maxitect",
     "estimatedCompletion": "2023-06-30T00:00:00.000Z",
     "createdAt": "2025-05-09T09:47:13.554Z",
-    "updatedAt": "2025-05-09T09:47:37.789Z"
+    "updatedAt": "2025-05-09T10:45:29.454Z"
   }
 ]

--- a/static/data/tasks.json
+++ b/static/data/tasks.json
@@ -1,1 +1,16 @@
-[]
+[
+  {
+    "id": "4e3474f7-7a68-4701-bdc8-a6a9e840e656",
+    "title": "Example Task",
+    "description": "This is an example task",
+    "status": "todo",
+    "labels": [
+      "feature",
+      "frontend"
+    ],
+    "assignee": "maxitect",
+    "estimatedCompletion": "2023-06-30T00:00:00.000Z",
+    "createdAt": "2025-05-09T09:47:13.554Z",
+    "updatedAt": "2025-05-09T09:47:37.789Z"
+  }
+]


### PR DESCRIPTION
# API Routes Development

## Original Ticket
- Implement GET /api/tasks endpoint
- Implement POST /api/tasks endpoint
- Implement GET/PUT/DELETE /api/tasks/[id] endpoints

## What I've Done
- Set up +server.ts inside `api/tasks/` endpoint serving the GET and POST `/tasks` routes
- Set up +server.ts inside `tasks/` endpoint serving the GET and POST routes

## How I Worked with Claude
- Shared `FUNCTIONAL.md`, `ARCHITECTURE.md` and `CLAUDE.md` with it to have context
- Shared context of `TICKETS.md` before main prompt
- Fed in one todo item at a time from the ticket to keep code in manageable, reviewable chunks at each stage
- Interrogated implementation
- Narrowed it's context window by summarising progress in `HISTORY_MAX.md`
- I reviewed the code and understand it but did not write any new code beyond Claude's suggestions
- In a second review I identified inefficiencies in Claude's code, whereby helper functions could be written and imported in both api route folders - explained to Claude and it implemented the solution

## Code Understanding
Set up 5 API routes:
- GET all tasks (in `api/tasks/+server.ts`)
- POST one task (in `api/tasks/+server.ts`)
- GET one task by id (in `api/tasks/[id]/+server.ts`)
- PUT one task by id (in `api/tasks/[id]/+server.ts`): this can update any field on the task
- DELETE one task by id (in `api/tasks/[id]/+server.ts`)

Set up 3 helper functions for easier api route functionality and error handling (in `lib/utils/taskFileUtils.ts`):
- errorResponse function: allows for multiple error handling situations across all api routes
- readTasks function: all api routes apart from POST need to read the tasks from the json file, this is a helper function that allows us to re-use the functionality in all routes
- writeTasks function: all api routes apart from GET need to write the tasks to the json file, this is a helper function that allows us to re-use the functionality in all routes

## Architectural Considerations
Seperated helper functions out of the api routes into the `utils/` folder for re-usability

## Testing Approach
Used POSTMAN to run tests on all api routes:
![image](https://github.com/user-attachments/assets/182a1359-c24c-4248-a897-b8ec21b65d9b)